### PR TITLE
Make logging levels configurable per module path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ log = "0.4"
 winit = "=0.20.0-alpha4"
 wgpu = "0.4"
 vk-shader-macros = "0.2.2"
+log = { version = "0.4", features = ["std"] }
 
 [features]
 sandbox = []

--- a/examples/cefsimple.rs
+++ b/examples/cefsimple.rs
@@ -36,8 +36,6 @@ impl LifeSpanHandlerCallbacks for LifeSpanHandlerImpl {
     }
 }
 
-static LOGGER: Logger = Logger;
-
 fn main() {
     let app = App::new(AppCallbacksImpl {});
     let result = cef::execute_process(Some(app.clone()), None);
@@ -50,7 +48,10 @@ fn main() {
     .locales_dir_path("./Resources/locales");
 
     let context = cef::Context::initialize(&settings, Some(app), None).unwrap();
-    log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Info)).unwrap();
+    let mut logger_builder = Logger::builder();
+    logger_builder.level(log::LevelFilter::Info);
+    let logger = Box::new(logger_builder.build());
+    log::set_boxed_logger(logger).map(|()| log::set_max_level(log::LevelFilter::Info)).unwrap();
     info!("Startup"); // This is the earliest you can use logging!
 
     let mut window_info = WindowInfo::new();

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,22 +1,33 @@
 use cef_sys::{cef_log, cef_log_severity_t, cef_get_min_log_level};
 use log::{Record, Level, Metadata};
+use std::borrow::Cow;
 use std::ffi::CString;
 
 /// Integration of Rust's log crate with CEF. Example usage:
 ///
 /// ```rust
-///  static LOGGER: cef::Logger = cef::Logger;
+///  let mut logger_builder = cef::logging::Logger::builder();
+///  logger_builder.level(log::LevelFilter::Warn);
+///  logger_builder.level_for_module_path("mycrate", log::LevelFilter::Debug);
+///  let logger = logger_builder.build();
 ///
-///  log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Info)).unwrap();
-///  info!("Hello World!");
+///  log::set_boxed_logger(Box::new(logger)).map(|()| log::set_max_level(log::LevelFilter::Info)).unwrap();
+///  log::info!("Hello World!");
 /// ```
 ///
 /// Note that you have to call [cef::Context::initialize] before logging can be used.
 /// Also, don't forget to configure CEF's log level, which is separate from the one managed by [log].
 /// Only if a message's level passes both filters, it will actually be logged.
-pub struct Logger;
+pub struct Logger {
+    level: log::LevelFilter,
+    module_path_levels: Vec<(Cow<'static, str>, log::LevelFilter)>,
+}
 
 impl Logger {
+    pub fn builder() -> LoggerBuilder {
+        LoggerBuilder::new()
+    }
+
     fn cef_level(level: Level) -> i32 {
         // for some reason, these are different than cef_log_severity_t!
         match level {
@@ -49,16 +60,71 @@ impl log::Log for Logger {
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
+            let log_module_path = record.module_path().or(record.module_path_static());
+            let log_level = record.metadata().level();
+
+            if let Some(log_module_path) = log_module_path {
+                let module_level = self
+                    .module_path_levels
+                    .iter()
+                    .find_map(|(module_path, level)| {
+                        if log_module_path.starts_with(module_path.as_ref()) {
+                            Some(level)
+                        } else {
+                            None
+                        }
+                    });
+                let active_level = module_level.unwrap_or(&self.level);
+
+                if log_level > *active_level {
+                    return;
+                }
+            }
+
             if let Ok(text) = CString::new(format!("{}", record.args()).as_bytes()) {
-                let file = CString::new(record.file().unwrap_or("<unknown>").as_bytes()).unwrap_or_else(|_| CString::new(b"<unknown>".to_vec()).unwrap());
+                let file = CString::new(record.file().unwrap_or("<unknown>").as_bytes())
+                    .unwrap_or_else(|_| CString::new(b"<unknown>".to_vec()).unwrap());
                 let line = record.line().unwrap_or(0);
-                let level = Self::cef_level(record.metadata().level());
+                let cef_log_level = Self::cef_level(log_level);
                 unsafe {
-                    cef_log(file.as_ptr(), line as _, level as _, text.as_ptr());
+                    cef_log(file.as_ptr(), line as _, cef_log_level as _, text.as_ptr());
                 }
             }
         }
     }
 
     fn flush(&self) {}
+}
+
+pub struct LoggerBuilder {
+    level: log::LevelFilter,
+    module_path_levels: Vec<(Cow<'static, str>, log::LevelFilter)>,
+}
+
+impl LoggerBuilder {
+    pub fn new() -> LoggerBuilder {
+        LoggerBuilder {
+            level: log::LevelFilter::Off,
+            module_path_levels: Vec::new(),
+        }
+    }
+
+    pub fn level(&mut self, level: log::LevelFilter) {
+        self.level = level;
+    }
+
+    pub fn level_for_module_path<S: Into<Cow<'static, str>>>(
+        &mut self,
+        module_path: S,
+        level: log::LevelFilter,
+    ) {
+        self.module_path_levels.push((module_path.into(), level));
+    }
+
+    pub fn build(self) -> Logger {
+        Logger {
+            level: self.level,
+            module_path_levels: self.module_path_levels,
+        }
+    }
 }


### PR DESCRIPTION
This is the most minimal and hacky functionality needed for configuring the `log::LevelFilter` per crate and module, as defined in https://git.dungeonfog.com/deios/deios/issues/78